### PR TITLE
delete href for modal support + use templateUrls 

### DIFF
--- a/src/app/cron-editor/cron-editor.component.ts
+++ b/src/app/cron-editor/cron-editor.component.ts
@@ -5,7 +5,7 @@ import { Days, MonthWeeks, Months } from "./enums";
 
 @Component({
     selector: "cron-editor",
-    templateUrls: "./cron-editor.template.html",
+    templateUrl: "./cron-editor.template.html",
     styleUrls: ["./cron-editor.component.css"]
 })
 export class CronGenComponent implements OnInit, OnChanges {

--- a/src/app/cron-editor/cron-editor.component.ts
+++ b/src/app/cron-editor/cron-editor.component.ts
@@ -5,8 +5,8 @@ import { Days, MonthWeeks, Months } from "./enums";
 
 @Component({
     selector: "cron-editor",
-    template: require("./cron-editor.template.html"),
-    styles: [require("./cron-editor.component.css").toString()]
+    templateUrls: "./cron-editor.template.html",
+    styleUrls: ["./cron-editor.component.css"]
 })
 export class CronGenComponent implements OnInit, OnChanges {
     @Input() public disabled: boolean;

--- a/src/app/cron-editor/cron-editor.template.html
+++ b/src/app/cron-editor/cron-editor.template.html
@@ -2,43 +2,43 @@
   <!-- Tabs -->
   <ul class="nav nav-tabs tab-nav" role="tablist">
     <li [ngClass]="{'active': activeTab === 'minutes'}" *ngIf="!options.hideMinutesTab">
-      <a href="#" aria-controls="minutes" role="tab" data-toggle="tab" (click)="setActiveTab('minutes')">
+      <a aria-controls="minutes" role="tab" data-toggle="tab" (click)="setActiveTab('minutes')">
         Minutes
       </a>
     </li>
 
     <li role="presentation" *ngIf="!options.hideHourlyTab" [ngClass]="{'active': activeTab === 'hourly'}">
-      <a href="#" aria-controls="hourly" role="tab" data-toggle="tab" (click)="setActiveTab('hourly')">
+      <a aria-controls="hourly" role="tab" data-toggle="tab" (click)="setActiveTab('hourly')">
         Hourly
       </a>
     </li>
 
     <li role="presentation" *ngIf="!options.hideDailyTab" [ngClass]="{'active': activeTab === 'daily'}">
-      <a href="#" aria-controls="daily" role="tab" data-toggle="tab" (click)="setActiveTab('daily')">
+      <a aria-controls="daily" role="tab" data-toggle="tab" (click)="setActiveTab('daily')">
         Daily
       </a>
     </li>
 
     <li role="presentation" *ngIf="!options.hideWeeklyTab" [ngClass]="{'active': activeTab === 'weekly'}">
-      <a href="#" aria-controls="weekly" role="tab" data-toggle="tab" (click)="setActiveTab('weekly')">
+      <a aria-controls="weekly" role="tab" data-toggle="tab" (click)="setActiveTab('weekly')">
         Weekly
       </a>
     </li>
 
     <li role="presentation" *ngIf="!options.hideMonthlyTab" [ngClass]="{'active': activeTab === 'monthly'}">
-      <a href="#" aria-controls="monthly" role="tab" data-toggle="tab" (click)="setActiveTab('monthly')">
+      <a aria-controls="monthly" role="tab" data-toggle="tab" (click)="setActiveTab('monthly')">
         Monthly
       </a>
     </li>
 
     <li role="presentation" *ngIf="!options.hideYearlyTab" [ngClass]="{'active': activeTab === 'yearly'}">
-      <a href="#" aria-controls="yearly" role="tab" data-toggle="tab" (click)="setActiveTab('yearly')">
+      <a aria-controls="yearly" role="tab" data-toggle="tab" (click)="setActiveTab('yearly')">
         Yearly
       </a>
     </li>
 
     <li role="presentation" *ngIf="!options.hideAdvancedTab" [ngClass]="{'active': activeTab === 'advanced'}">
-      <a href="#" aria-controls="advanced" role="tab" data-toggle="tab" (click)="setActiveTab('advanced')">
+      <a aria-controls="advanced" role="tab" data-toggle="tab" (click)="setActiveTab('advanced')">
         Advanced
       </a>
     </li>

--- a/src/app/cron-editor/cron-time-picker.component.ts
+++ b/src/app/cron-editor/cron-time-picker.component.ts
@@ -2,7 +2,7 @@
 
 @Component({
     selector: "cron-time-picker",
-    templateUrls: "./cron-time-picker.template.html"
+    templateUrl: "./cron-time-picker.template.html"
 })
 export class TimePickerComponent implements OnInit {
     @Output() public onChange = new EventEmitter();

--- a/src/app/cron-editor/cron-time-picker.component.ts
+++ b/src/app/cron-editor/cron-time-picker.component.ts
@@ -2,7 +2,7 @@
 
 @Component({
     selector: "cron-time-picker",
-    template: require("./cron-time-picker.template.html")
+    templateUrls: "./cron-time-picker.template.html"
 })
 export class TimePickerComponent implements OnInit {
     @Output() public onChange = new EventEmitter();


### PR DESCRIPTION
Hi,
by removing the 'href' part you can support modal
**Before**
`<li role="presentation" *ngIf="!options.hideAdvancedTab" [ngClass]="{'active': activeTab === 'advanced'}"> <a href="#" aria-controls="advanced" role="tab" data-toggle="tab" (click)="setActiveTab('advanced')"> Advanced </a> </li>`
**After**
`<li role="presentation" *ngIf="!options.hideAdvancedTab" [ngClass]="{'active': activeTab === 'advanced'}"> <a aria-controls="advanced" role="tab" data-toggle="tab" (click)="setActiveTab('advanced')"> Advanced </a> </li>`

href closes modal on click.
Referring to:
_src/app/cron-editor/cron-editor.template.html_
Thanks,

Rudraken