### PR TITLE
make default advanced cron valid when seconds or years are removed

### DIFF
--- a/projects/cron-editor/src/lib/cron-editor.component.ts
+++ b/projects/cron-editor/src/lib/cron-editor.component.ts
@@ -373,14 +373,17 @@ export class CronEditorComponent implements OnInit, OnChanges {
   }
 
   private getDefaultAdvancedCronExpression(): string {
-    if (this.options.removeSeconds && !this.options.removeYears)
+    if (this.options.removeSeconds && !this.options.removeYears) {
       return '15 10 L-2 * ? 2019';
+    }
 
-    if (!this.options.removeSeconds && this.options.removeYears)
+    if (!this.options.removeSeconds && this.options.removeYears) {
       return '0 15 10 L-2 * ?';
+    }
 
-    if (this.options.removeSeconds && this.options.removeYears)
-      return '15 10 L-2 * ?';      
+    if (this.options.removeSeconds && this.options.removeYears) {
+      return '15 10 L-2 * ?';
+    }
 
     return '0 15 10 L-2 * ? 2019';
   }

--- a/projects/cron-editor/src/lib/cron-editor.component.ts
+++ b/projects/cron-editor/src/lib/cron-editor.component.ts
@@ -372,6 +372,19 @@ export class CronEditorComponent implements OnInit, OnChanges {
     return;
   }
 
+  private getDefaultAdvancedCronExpression(): string {
+    if (this.options.removeSeconds && !this.options.removeYears)
+      return '15 10 L-2 * ? 2019';
+
+    if (!this.options.removeSeconds && this.options.removeYears)
+      return '0 15 10 L-2 * ?';
+
+    if (this.options.removeSeconds && this.options.removeYears)
+      return '15 10 L-2 * ?';      
+
+    return '0 15 10 L-2 * ? 2019';
+  }
+
   private getDefaultState() {
     const [defaultHours, defaultMinutes, defaultSeconds] = this.options.defaultTime.split(':').map(Number);
 
@@ -455,7 +468,7 @@ export class CronEditorComponent implements OnInit, OnChanges {
         }
       },
       advanced: {
-        expression: '0 15 10 L-2 * ?'
+        expression: this.getDefaultAdvancedCronExpression()
       },
       validation: {
         isValid: true,


### PR DESCRIPTION
Default cron expression for the advanced tab was not valid in conjunction with removeSeconds or removeYears. Now on these cases, we return valid default crons.