### PR TITLE
Fix months value being incorrectly set when month is represented by a 2-digit number

### DIFF
--- a/projects/cron-editor/src/lib/cron-editor.component.ts
+++ b/projects/cron-editor/src/lib/cron-editor.component.ts
@@ -320,8 +320,9 @@ export class CronEditorComponent implements OnInit, OnChanges {
       this.state.monthly.specificWeekDay.day = day;
 
       if (month.indexOf('/') !== -1) {
-        this.state.monthly.specificWeekDay.months = Number(month.substring(2));
-        this.state.monthly.specificWeekDay.startMonth = Number(month.split('/')[0]);
+        const [startMonth, months] = month.split('/').map(Number);
+        this.state.monthly.specificWeekDay.months = months;
+        this.state.monthly.specificWeekDay.startMonth = startMonth;
       }
 
       const parsedHours = Number(hours);


### PR DESCRIPTION
Trying to show a cron expression similar to `"On the first <DAY> of every <N> month(s) starting in <MONTH>..."`, where `MONTH` is represented by a 2-digit number (i.e. October through December) would result in `N` not being displayed.

This was caused by the fact that `month` would have an extra character before `/` and we would end up with something like `Number('/1')` which is `NaN`.