### PR TITLE
Added month selection to Monthly tab

### DIFF
--- a/projects/cron-editor/src/lib/cron-editor.component.css
+++ b/projects/cron-editor/src/lib/cron-editor.component.css
@@ -37,7 +37,7 @@
 }
 
 .cron-editor-container .months-small {
-    width: 60px;
+    width: 80px;
 }
 
 .cron-editor-container .day-order-in-month {

--- a/projects/cron-editor/src/lib/cron-editor.component.html
+++ b/projects/cron-editor/src/lib/cron-editor.component.html
@@ -193,6 +193,80 @@
                         </cron-time-picker>&nbsp;
                         <label class="advanced-cron-editor-label"><input type="checkbox" [disabled]="disabled || activeTab !== 'monthly' || state.monthly.subTab !== 'specificDay'" 
                             (change)="regenerateCron()" [(ngModel)]="state.monthly.runOnWeekday" [ngClass]="options.formCheckboxClass"> during the nearest weekday</label>
+                        <div class="row">
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.JAN" [ngClass]="options.formCheckboxClass"
+                                > Janurary</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.FEB" [ngClass]="options.formCheckboxClass"
+                                > Feburary</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.MAR" [ngClass]="options.formCheckboxClass"
+                                > March</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.APR" [ngClass]="options.formCheckboxClass"
+                                > April</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.MAY" [ngClass]="options.formCheckboxClass"
+                                > May</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.JUN" [ngClass]="options.formCheckboxClass"
+                                > June</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.specificDay.JUL" [ngClass]="options.formCheckboxClass"
+                                > July</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.AUG" [ngClass]="options.formCheckboxClass"
+                                > August</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.SEP" [ngClass]="options.formCheckboxClass"
+                                > September</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.OCT" [ngClass]="options.formCheckboxClass"
+                                > October</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.NOV" [ngClass]="options.formCheckboxClass"
+                                > November</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.DEC" [ngClass]="options.formCheckboxClass"
+                                > December</label>
+                            </div>
+                        </div>
                     </div>
                     <div class="well well-small">
                         <input type="radio" name="monthly-radio" value="specificWeekDay" [disabled]="disabled" (change)="regenerateCron()"

--- a/projects/cron-editor/src/lib/cron-editor.component.html
+++ b/projects/cron-editor/src/lib/cron-editor.component.html
@@ -233,7 +233,7 @@
                             <div class="col-xs-4 col-sm-3">
                                 <label class="advanced-cron-editor-label"><input type="checkbox" 
                                     [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
-                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.specificDay.JUL" [ngClass]="options.formCheckboxClass"
+                                    (change)="regenerateCron()" [(ngModel)]="state.monthly.JUL" [ngClass]="options.formCheckboxClass"
                                 > July</label>
                             </div>
                             <div class="col-xs-4 col-sm-3">
@@ -265,6 +265,11 @@
                                     [disabled]="disabled || activeTab !== 'monthly' || state.monthly.specificDay.months !== 'selected'" 
                                     (change)="regenerateCron()" [(ngModel)]="state.monthly.DEC" [ngClass]="options.formCheckboxClass"
                                 > December</label>
+                            </div>
+                            <div class="col-xs-4 col-sm-3">
+                                <label class="advanced-cron-editor-label"><input type="checkbox" 
+                                    [disabled]="true" [ngModel]="allMonthsSelected()" [ngClass]="options.formCheckboxClass"
+                                > All Months</label>
                             </div>
                         </div>
                     </div>

--- a/projects/cron-editor/src/lib/cron-editor.component.ts
+++ b/projects/cron-editor/src/lib/cron-editor.component.ts
@@ -151,8 +151,21 @@ export class CronEditorComponent implements OnInit, OnChanges {
         switch (this.state.monthly.subTab) {
           case 'specificDay':
             const day = this.state.monthly.runOnWeekday ? `${this.state.monthly.specificDay.day}W` : this.state.monthly.specificDay.day;
+            let months = "";
+            if( this.state.monthly.specificDay.months === 'selected' ) {
+              months = this.selectOptions.monthNames
+                .reduce((acc, month) => this.state.monthly[month] ? acc.concat([month]) : acc, [])
+                .join(',');
+
+              if( months.length === 0 ) {
+                months = "*";
+              }
+            } else {
+              months = `1/${this.state.monthly.specificDay.months}`;
+            } 
+
             // tslint:disable-next-line:max-line-length
-            this.cron = `${this.state.monthly.specificDay.minutes} ${this.hourToCron(this.state.monthly.specificDay.hours, this.state.monthly.specificDay.hourType)} ${day} 1/${this.state.monthly.specificDay.months} ?`;
+            this.cron = `${this.state.monthly.specificDay.minutes} ${this.hourToCron(this.state.monthly.specificDay.hours, this.state.monthly.specificDay.hourType)} ${day} ${months} ?`;
 
             if (!this.options.removeSeconds) {
               this.cron = `${this.state.monthly.specificDay.seconds} ${this.cron}`;
@@ -457,6 +470,18 @@ export class CronEditorComponent implements OnInit, OnChanges {
       monthly: {
         subTab: 'specificDay',
         runOnWeekday: false,
+        JAN: false,
+        FEB: false,
+        MAR: false,
+        APR: false,
+        MAY: false,
+        JUN: false,
+        JUL: false,
+        AUG: false,
+        SEP: false,
+        OCT: false,
+        NOV: false,
+        DEC: false,
         specificDay: {
           day: '1',
           months: 1,
@@ -530,9 +555,10 @@ export class CronEditorComponent implements OnInit, OnChanges {
 
   private getSelectOptions() {
     return {
-      months: Utils.getRange(1, 12),
+      months: ['selected', ...Utils.getRange(1, 12)],
       monthWeeks: ['#1', '#2', '#3', '#4', '#5', 'L'],
       days: ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'],
+      monthNames: ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV'],
       minutes: Utils.getRange(0, 59),
       fullMinutes: Utils.getRange(0, 59),
       seconds: Utils.getRange(0, 59),

--- a/projects/cron-editor/src/lib/cron-editor.component.ts
+++ b/projects/cron-editor/src/lib/cron-editor.component.ts
@@ -77,6 +77,10 @@ export class CronEditorComponent implements OnInit, OnChanges {
     }
   }
 
+  public allMonthsSelected(): boolean {
+    return !this.selectOptions.monthNames.find( month => this.state.monthly[month] )
+  }
+
   public regenerateCron() {
     this.isDirty = true;
 
@@ -307,7 +311,7 @@ export class CronEditorComponent implements OnInit, OnChanges {
       this.state.weekly.hourType = this.getHourType(parsedHours);
       this.state.weekly.minutes = Number(minutes);
       this.state.weekly.seconds = Number(seconds);
-    } else if (cronSeven.match(/\d+ \d+ \d+ (\d+|L|LW|1W) 1\/\d+ \? \*/)) {
+    } else if (cronSeven.match(/\d+ \d+ \d+ (\d+|L|LW|1W) ((1\/\d+)|((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(,(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))*)|\*) \? \*/)) {
       this.activeTab = 'monthly';
       this.state.monthly.subTab = 'specificDay';
 
@@ -318,7 +322,12 @@ export class CronEditorComponent implements OnInit, OnChanges {
         this.state.monthly.specificDay.day = dayOfMonth;
       }
 
-      this.state.monthly.specificDay.months = Number(month.substring(2));
+      const firstChar = month.charAt(0);
+      this.state.monthly.specificDay.months = ( firstChar === '*' || isNaN(Number(firstChar)) ) ? this.selectOptions.months[0] : Number(month.substring(2));
+      this.selectOptions.monthNames.forEach(month => this.state.monthly[month] = false);
+      if( this.state.monthly.specificDay.months === this.selectOptions.months[0] ) {
+        month.split(',').forEach(month => this.state.monthly[month] = true);
+      }
       const parsedHours = Number(hours);
       this.state.monthly.specificDay.hours = this.getAmPmHour(parsedHours);
       this.state.monthly.specificDay.hourType = this.getHourType(parsedHours);
@@ -558,7 +567,7 @@ export class CronEditorComponent implements OnInit, OnChanges {
       months: ['selected', ...Utils.getRange(1, 12)],
       monthWeeks: ['#1', '#2', '#3', '#4', '#5', 'L'],
       days: ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'],
-      monthNames: ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV'],
+      monthNames: ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'],
       minutes: Utils.getRange(0, 59),
       fullMinutes: Utils.getRange(0, 59),
       seconds: Utils.getRange(0, 59),


### PR DESCRIPTION
Added the ability for the user to specify individual months in the monthly tab.

The current default screen is maintained. 
The options for each month are disabled.
<img width="978" alt="Screen Shot 2020-01-03 at 6 27 12 pm" src="https://user-images.githubusercontent.com/2238424/71713746-bfe8ed80-2e56-11ea-8380-d5c533cbf5ba.png">

The new functionality is activated by choosing "Selected" from the month number field
<img width="964" alt="Screen Shot 2020-01-03 at 6 29 52 pm" src="https://user-images.githubusercontent.com/2238424/71713830-0dfdf100-2e57-11ea-96b7-cc057bbbfcea.png">

When no individual months are selected, the output will default to all months, represented by a read-only check box. This satisfies the requirement of a valid cron expression in the output
<img width="981" alt="Screen Shot 2020-01-03 at 6 30 19 pm" src="https://user-images.githubusercontent.com/2238424/71713845-1f46fd80-2e57-11ea-92a4-73442b9e4a8c.png">

Selecting one or more months will result in an ordered list of 3 letter months in upper case
<img width="971" alt="Screen Shot 2020-01-03 at 6 31 04 pm" src="https://user-images.githubusercontent.com/2238424/71713888-456c9d80-2e57-11ea-8c24-061d0054483f.png">