### PR TITLE
Update for Bootstrap > 3 (4+)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,95 @@
-/* You can add global styles to this file, and also import other style files */
+
+.cron-editor-container {
+    padding-left: 10px;
+  }
+  
+  .cron-editor-container .cron-editor-radio {
+    width: 20px;
+    display: inline-block;
+  }
+  
+  .cron-editor-container .cron-editor-select,
+  .cron-editor-container .cron-editor-input,
+  .cron-editor-container .cron-editor-checkbox {
+    display: inline;
+  }
+  
+  .cron-editor-container .well-time-wrapper {
+    padding-left: 20px;
+  }
+  
+  .cron-editor-container .inline-block {
+    display: inline-block;
+  }
+  
+  .cron-editor-container .minutes,
+  .cron-editor-container .hours,
+  .cron-editor-container .days,
+  .cron-editor-container .seconds {
+    width: 70px;
+  }
+  
+  .cron-editor-container .months {
+    width: 120px;
+  }
+  
+  .cron-editor-container .month-days {
+    width: 130px;
+  }
+  
+  .cron-editor-container .months-small {
+    width: 60px;
+  }
+  
+  .cron-editor-container .day-order-in-month {
+    width: 95px;
+  }
+  
+  .cron-editor-container .week-days {
+    width: 120px;
+  }
+  
+  .cron-editor-container .advanced-cron-editor-input {
+    width: 200px;
+  }
+  
+  .cron-editor-container .hour-types {
+    width: 70px;
+  }
+  
+  .cron-editor-container .advanced-cron-editor-label {
+    font-weight: 200;
+  }
+
+  .nav-tabs li {
+    height: 50px;
+  }
+
+  .nav li a:hover,
+    .nav li.active a:focus,
+    .nav li.active a:hover{
+    background-color:gray;
+    }
+
+  .nav li.active a{
+        color: #000;
+        background-color:cyan;
+    }
+
+  .nav-tabs li a {
+    border-width: 1px;
+    border-color: black;
+    border-left-style: solid;
+    border-top-style: solid;
+    border-right-style: solid;
+    border-bottom-style: none;
+    cursor: context-menu;
+    padding: 27px;
+    font-weight: bolder;
+    font-display: block;
+    font-size: larger;
+  }
+
+  .form-control {
+    height: auto;
+  }


### PR DESCRIPTION
CSS for displaying the Cron Editor in a presentable format as bootstrap 3's styling is no longer valid for bootstrap 4+